### PR TITLE
Prevent random number from ever being zero

### DIFF
--- a/examples/with_cake/main.tf
+++ b/examples/with_cake/main.tf
@@ -1,6 +1,6 @@
 resource "random_integer" "cake_pos" {
   max = var.length - 1
-  min = 0
+  min = 1
 }
 
 


### PR DESCRIPTION
This fixes an edge case where the random number chosen is zero. That seems to break some of the code.