### PR TITLE
Fix upper range boundary

### DIFF
--- a/examples/with_cake/main.tf
+++ b/examples/with_cake/main.tf
@@ -1,5 +1,5 @@
 resource "random_integer" "cake_pos" {
-  max = var.length - 1
+  max = var.length - 2
   min = 1
 }
 


### PR DESCRIPTION
The issue seems to be in the length of the called module. This is a new edge case when `cake_pos == var.length - 1` which leads to `cake_suffix.length == (var.length - 1) - (var.length - 1) == 0`. The previous fix only handled the `cake_prefix.length == 0` case.