### PR TITLE
feat: update golangci-lint version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
 terraform 1.1.4
 tflint 0.34.1
 golang 1.17.6
-golangci-lint 1.46.2
+golangci-lint 1.52.2
 nodejs 16.13.2
 opa 0.36.1
 conftest v0.30.0


### PR DESCRIPTION
* Update to version 1.52.2 of golangci-lint to reduce occurances of this error:
```
ERROR Running error: 1 error occurred:
	* can't run linter goanalysis_metalinter: buildir: failed to load package goarch: could not load export data: cannot import "internal/goarch" 
```
