### PR TITLE
Update .gitignore to exclude pre-commit hook configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ terraform.rc
 azure_env.sh
 .releaserc.json
 .tflint.hcl
+
+# Pre-commit hook
+.pre-commit-config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ crash.*.log
 # control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars.json
+*.auto.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in


### PR DESCRIPTION
This file is populated by CAF and shouldn't be checked into TF modules.