### PR TITLE
chore: .pre-commit-config.yaml comes from CAF module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,0 @@
-components/module/linkfiles/.pre-commit-config.yaml


### PR DESCRIPTION
this file should not be committed, it comes from the caf-components-tf-module repo via `make configure`