### PR TITLE
Feature/1256

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CAF_ENV_FILE = .cafenv
 REPO_MANIFESTS_URL ?= https://github.com/nexient-llc/common-automation-framework.git
 # Branch of source repository for repo manifests. Other tags not currently supported.
 # TODO: replace with git tag when supported
-REPO_BRANCH ?= refs/tags/0.1.1
+REPO_BRANCH ?= main
 # Path to seed manifest in repository referenced in REPO_MANIFESTS_URL
 REPO_MANIFEST ?= manifests/terraform_modules/seed/manifest.xml
 

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ REPO_BRANCH ?= main
 # Path to seed manifest in repository referenced in REPO_MANIFESTS_URL
 REPO_MANIFEST ?= manifests/terraform_modules/seed/manifest.xml
 
-# Optional settings to pull in a different version of the repo utility.
+## Optional settings to pull in a different version of the repo utility.
 # REPO_URL ?= https://github.com/nexient-llc/git-repo.git
-# Branch or refs/tags of the repository referenced by REPO_URL to use
+## Branch or refs/tags of the repository referenced by REPO_URL to use
 # REPO_REV ?= main
 # export REPO_REV REPO_URL
 

--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,9 @@ configure: configure-git-hooks
 		-b "$(REPO_BRANCH)" \
 		-m "$(REPO_MANIFEST)"
     # Loop through files and substitute variables
-	find .repo/manifests -type f -exec sed -i -e "s|\$${GITBASE}|${GITBASE}|" ./{} \;
+    find .repo/manifests -type f -exec sed -i -e "s|\$${GITBASE}|${GITBASE}|" ./{} \;
     # Use the version of repo that was downloaded during "repo init" command above
-	.repo/repo/repo sync
+    .repo/repo/repo sync
 
 # The first line finds and removes all the directories pulled in by repo
 # The second line finds and removes all the broken symlinks from removing things

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CAF_ENV_FILE = .cafenv
 REPO_MANIFESTS_URL ?= https://github.com/nexient-llc/common-automation-framework.git
 # Branch of source repository for repo manifests. Other tags not currently supported.
 # TODO: replace with git tag when supported
-REPO_BRANCH ?= main
+REPO_BRANCH ?= refs/tags/0.1.1
 # Path to seed manifest in repository referenced in REPO_MANIFESTS_URL
 REPO_MANIFEST ?= manifests/terraform_modules/seed/manifest.xml
 
@@ -76,16 +76,17 @@ endef
 configure: git-auth
 endif
 
+# First, run repo init
+# Then, loop through files and substitute variables
+# Finally, Use the version of repo that was downloaded during "repo init" command above
 .PHONY: configure
 configure: configure-git-hooks
 	repo --color=never init --no-repo-verify \
 		-u "$(REPO_MANIFESTS_URL)" \
 		-b "$(REPO_BRANCH)" \
 		-m "$(REPO_MANIFEST)"
-    # Loop through files and substitute variables
-    find .repo/manifests -type f -exec sed -i -e "s|\$${GITBASE}|${GITBASE}|" ./{} \;
-    # Use the version of repo that was downloaded during "repo init" command above
-    .repo/repo/repo sync
+	find .repo/manifests -type f -exec sed -i -e "s|\$${GITBASE}|${GITBASE}|" ./{} \;
+	.repo/repo/repo sync
 
 # The first line finds and removes all the directories pulled in by repo
 # The second line finds and removes all the broken symlinks from removing things

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ endif
 
 # First, run repo init
 # Then, loop through files and substitute variables
-# Finally, Use the version of repo that was downloaded during "repo init" command above
+# Finally, use the version of repo that was downloaded during "repo init" command above
 .PHONY: configure
 configure: configure-git-hooks
 	repo --color=never init --no-repo-verify \

--- a/Makefile
+++ b/Makefile
@@ -19,16 +19,15 @@ CAF_ENV_FILE = .cafenv
 REPO_MANIFESTS_URL ?= https://github.com/nexient-llc/common-automation-framework.git
 # Branch of source repository for repo manifests. Other tags not currently supported.
 # TODO: replace with git tag when supported
-REPO_BRANCH ?= main
+REPO_BRANCH ?= refs/tags/0.1.1
 # Path to seed manifest in repository referenced in REPO_MANIFESTS_URL
 REPO_MANIFEST ?= manifests/terraform_modules/seed/manifest.xml
 
-# Settings to pull in Nexient version of (google) repo utility that supports environment substitution:
-REPO_URL ?= https://github.com/nexient-llc/git-repo.git
-# Branch of the repository referenced by REPO_URL to use
-# TODO: replace with git tag when supported
-REPO_REV ?= main
-export REPO_REV REPO_URL
+# Optional settings to pull in a different version of the repo utility.
+# REPO_URL ?= https://github.com/nexient-llc/git-repo.git
+# Branch or refs/tags of the repository referenced by REPO_URL to use
+# REPO_REV ?= main
+# export REPO_REV REPO_URL
 
 # Example variable to substituted after init, but before sync in repo manifests.
 GITBASE ?= https://github.com/nexient-llc/
@@ -83,8 +82,10 @@ configure: configure-git-hooks
 		-u "$(REPO_MANIFESTS_URL)" \
 		-b "$(REPO_BRANCH)" \
 		-m "$(REPO_MANIFEST)"
-	repo envsubst
-	repo sync
+    # Loop through files and substitute variables
+	find .repo/manifests -type f -exec sed -i -e "s|\$${GITBASE}|${GITBASE}|" ./{} \;
+    # Use the version of repo that was downloaded during "repo init" command above
+	.repo/repo/repo sync
 
 # The first line finds and removes all the directories pulled in by repo
 # The second line finds and removes all the broken symlinks from removing things


### PR DESCRIPTION
**Ticket:**
https://dev.azure.com/Nexient-internal/DSO%20Bench/_workitems/edit/1256

**What Changed:**
- Updated CAF branch from main to 0.1.1
- Made the REPO_URL and REPO_REV optional by commenting them out.
- Removed the `repo envsubst` command
- Added a command to perform variable substitution without the modified git-repo fork (right now there is only 1 variable to change. Ideally we would use the `envsubst` shell command but not all systems have it installed.)
- Use the git-repo tool downloaded by the repo init command instead of using the local version of git-repo