### PR TITLE
Bump tool-versions to be in sync with golangci-lint version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 conftest 0.44.1
 golang 1.20.8
-golangci-lint 1.53.3
+golangci-lint 1.55.2
 pre-commit 3.3.3
 terraform 1.5.5
 terraform-docs 0.16.0


### PR DESCRIPTION
Ensures pre-commit and local development use the same version of the `golangci-lint` tool