### PR TITLE
Add ignore for Terratest's .test-data folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ components/
 # We don't want to commit the test run lock files
 .terraform.lock.hcl
 
+# Don't include the .test-data directory created by Terratest's test-structure module
+**/.test-data/*
+
 # Local .terraform directories
 **/.terraform/*
 


### PR DESCRIPTION
Not all of our tests utilize the `test-structure` module to cache data between tests, but for those that do, we don't want to commit that test data.