### PR TITLE
make configure installs dependencies from .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,6 +2,7 @@ conftest 0.44.1
 golang 1.20.8
 golangci-lint 1.55.2
 pre-commit 3.3.3
+regula 3.2.1 # https://github.com/nexient-llc/asdf-regula
 terraform 1.5.5
 terraform-docs 0.16.0
 terragrunt 0.39.2

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,20 @@ COMPONENTS_DIR = components
 
 MODULE_DIR ?= ${COMPONENTS_DIR}/module
 
+PYTHON3_INSTALLED = $(shell which python3 > /dev/null 2>&1; echo $$?)
+MISE_INSTALLED = $(shell which mise > /dev/null 2>&1; echo $$?)
+ASDF_INSTALLED = $(shell which asdf > /dev/null 2>&1; echo $$?)
+REPO_INSTALLED = $(shell which repo > /dev/null 2>&1; echo $$?)
+GIT_USER_SET = $(shell git config --get user.name > /dev/null 2>&1; echo $$?)
+GIT_EMAIL_SET = $(shell git config --get user.name > /dev/null 2>&1; echo $$?)
+
 .PHONY: configure-git-hooks
-configure-git-hooks:
+configure-git-hooks: configure-dependencies
+ifeq ($(PYTHON3_INSTALLED), 0)
 	pre-commit install
+else
+	$(error Missing python3, which is required for pre-commit. Install python3 and rerun.)
+endif
 
 ifeq ($(IS_PIPELINE),true)
 .PHONY: git-config
@@ -76,14 +87,33 @@ endef
 configure: git-auth
 endif
 
+.PHONY: configure-dependencies
+configure-dependencies:
+ifeq ($(MISE_INSTALLED), 0)
+	@echo "Installing dependencies using mise"
+	@awk -F'[ #]' '$$NF ~ /https/ {system("mise plugin install " $$1 " " $$NF " --yes")} $$1 ~ /./ {system("mise install " $$1 " " $$2 " --yes")}' ./.tool-versions
+else ifeq ($(ASDF_INSTALLED), 0)
+	@echo "Installing dependencies using asdf-vm"
+	@awk -F'[ #]' '$$NF ~ /https/ {system("asdf plugin add " $$1 " " $$NF)} $$1 ~ /./ {system("asdf plugin add " $$1 "; asdf install " $$1 " " $$2)}' ./.tool-versions
+else
+	$(error Missing supported dependency manager. Install asdf-vm (https://asdf-vm.com/) or mise (https://mise.jdx.dev/) and rerun)
+endif
+
 .PHONY: configure
 configure: configure-git-hooks
-	repo --color=never init --no-repo-verify \
+ifneq ($(and $(GIT_USER_SET), $(GIT_EMAIL_SET)), 0)
+	$(error Git identities are not set! Set your user.name and user.email using 'git config' and rerun)
+endif
+ifeq ($(REPO_INSTALLED), 0)
+	echo n | repo --color=never init --no-repo-verify \
 		-u "$(REPO_MANIFESTS_URL)" \
 		-b "$(REPO_BRANCH)" \
 		-m "$(REPO_MANIFEST)"
 	repo envsubst
 	repo sync
+else
+	$(error Missing Repo, which is required for platform sync. Install Repo (https://gerrit.googlesource.com/git-repo) and rerun.)
+endif
 
 # The first line finds and removes all the directories pulled in by repo
 # The second line finds and removes all the broken symlinks from removing things

--- a/README.md
+++ b/README.md
@@ -19,20 +19,10 @@ This repo is intended to be used as a template for any new TF module. In some ca
 
 ### Repo Init
 
-Run the following commands to prep repo and enable all `Makefile` commands to run
+Run the following command to prep repo and enable all `Makefile` commands to run
 
 ```shell
-asdf plugin add terraform
-asdf plugin add tflint
-asdf plugin add golang
-asdf plugin add golangci-lint
-asdf plugin add nodejs
-asdf plugin add opa
-asdf plugin add conftest
-asdf plugin add pre-commit
-asdf plugin add terragrunt
-
-asdf install
+make configure
 ```
 
 ### Templating
@@ -76,7 +66,7 @@ TBD
 
 #### Overriding Make Behavior
 
-When run, `make` will look for a file called `.cafenv` in the repository root. This file if present will be included, and it can be used to override variables without altering the [Makefile](Makefile). A few examples of variables that can be substituted are commented out in [the file](.cafenv).
+When run, `make` will look for a file called `.lcafenv` in the repository root. This file if present will be included, and it can be used to override variables without altering the [Makefile](Makefile). A few examples of variables that can be substituted are commented out in [the file](.lcafenv).
 
 #### Module Configuration
 
@@ -96,9 +86,9 @@ When run, `make` will look for a file called `.cafenv` in the repository root. T
   - Should have default values and be instantiable with minimal to no inputs
   - We can think of these default values as the "default example"
 - A `Makefile` provides tasks for terraform module development
-  - It will clone and cache `caf-components-tf-module` and `caf-components-platform` git repositories when a `make configure` is ran
+  - It will clone and cache `lcaf-component-tf-module` and `lcaf-component-platform` git repositories when a `make configure` is ran
   - For clearing cached components, it provides a `make clean` command
-  - Linter config and all other tasks are defined in `caf-components-tf-module`
+  - Linter config and all other tasks are defined in `lcaf-component-tf-module`
 - An `examples` folder contains example uses of the default and nested modules
   - There should be at least one example for each nested module
 - A `tests` folder contains Go functional tests


### PR DESCRIPTION
Adds a few capabilities and fixes:

* `make configure` now installs all dependencies specified in the `.tool-versions` file in addition to synchronizing all the component repositories from the platform.
    * Fixes a longstanding issue on brand new installations where `pre-commit` didn't necessarily exist and could cause a failure during `make configure`.
* Adds support for custom repositories in our `.tool-versions` file. In order to utilize this capability, you must use a comment at the end of the line that has the repository from which the tool should be installed. The URL must be the last part of the line, no other text may follow it.

```shell
# Contents of .tool-versions
# Comments on their own line are just fine if you need them
pre-commit 3.3.3 # End-of-line comments without a URL still work as expected
# The following line specifies a tool that is not part of the community registry:
regula 3.2.1 # https://github.com/nexient-llc/asdf-regula
```

* Adds support for `mise`, a compatible alternative to `asdf`, to dependency installation. If the user has `mise` installed on their system, it will be preferred over `asdf`.
* Adds error messaging to file down several sharp edges:
    * If the user does not have the `repo` tool installed, they will be instructed to install it.
    * If the user has neither `asdf` nor `mise` installed, they will be instructed to install one.
    * If the user does not have Python3 installed, they will be instructed to install it.
    * If the user does not have their git identity (user.name, user.email) set, they will be instructed to set it.
* Adds a workaround for `--color=never` not being respected in Docker containers (echoing a default selection of "n" to the color prompt).
* Adds our `regula` package to the skeleton.
* README tweaks. This README is fairly out of date and probably needs a full review, which is out of scope for this change.