### PR TITLE
Export _VER variables, bump REPO_BRANCH to latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,18 @@
 LCAF_ENV_FILE = .lcafenv
 -include $(LCAF_ENV_FILE)
 
+export PLATFORM_VER
+export CONTAINER_VER
+export PIPELINES_VER
+export WEBHOOK_VER
+export PYTHON_VER
+export TERRAGRUNT_VER
+export TERRAFORM_VER
+
 # Source repository for repo manifests
 REPO_MANIFESTS_URL ?= https://github.com/nexient-llc/launch-common-automation-framework.git
 # Branch of source repository for repo manifests. Other tags not currently supported.
-REPO_BRANCH ?= refs/tags/0.2.1
+REPO_BRANCH ?= refs/tags/0.3.0
 # Path to seed manifest in repository referenced in REPO_MANIFESTS_URL
 REPO_MANIFEST ?= manifests/terraform_modules/seed/manifest.xml
 


### PR DESCRIPTION
Adds an export for the _VER variables that are included from `.lcafenv`. Previously, these variables would have only been scoped to the Makefiles, which causes a problem when running `repo envsubst` because the expected variables are not yet a part of the environment.

There's probably a more elegant solution to be had here (maybe filter in-scope variables to those that end in _VAR and export those dynamically?) so if someone else wants to make an attempt at that, be my guest. For now, if we add new variables to `.lcafenv` that need to be substituted into manifest definitions, one will need to manually add an export statement for that var.

Requires https://github.com/nexient-llc/launch-common-automation-framework/pull/19 to be merged and tagged prior to merge.