### PR TITLE
patch: bump lcaf-component-terratest-common version to 1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/gruntwork-io/terratest v0.43.12
-	github.com/nexient-llc/lcaf-component-terratest-common v0.0.0-20240117163707-a1dfafae58b4
+	github.com/nexient-llc/lcaf-component-terratest-common v1.0.1
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -453,8 +453,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nexient-llc/lcaf-component-terratest-common v0.0.0-20240117163707-a1dfafae58b4 h1:d159w/9sreYb3dJg+s1XGO0bIr00JtjrdgJf6z7eCnI=
-github.com/nexient-llc/lcaf-component-terratest-common v0.0.0-20240117163707-a1dfafae58b4/go.mod h1:g3lD3RGQNlbd66ngNJnxA7hjjfEL+YAEksN0nxK9Ddc=
+github.com/nexient-llc/lcaf-component-terratest-common v1.0.1 h1:02QNmEXpvgwR7ZM2WE5apZCop1DDO4i6oElO+440Hms=
+github.com/nexient-llc/lcaf-component-terratest-common v1.0.1/go.mod h1:nwqtaMSv/k+mTv+yDDJF+0IGmTxdty9a2Z5GTxIQVGY=
 github.com/onsi/ginkgo/v2 v2.9.1 h1:zie5Ly042PD3bsCvsSOPvRnFwyo3rKe64TJlD6nu0mk=
 github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
- bumping `lcaf-component-terratest-common` version: `0.0.0-20240117163707-a1dfafae58b4` -> `1.0.1`