### PR TITLE
Temporarily revert export behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,6 @@
 LCAF_ENV_FILE = .lcafenv
 -include $(LCAF_ENV_FILE)
 
-export PLATFORM_VER
-export CONTAINER_VER
-export PIPELINES_VER
-export WEBHOOK_VER
-export PYTHON_VER
-export TERRAGRUNT_VER
-export TERRAFORM_VER
-
 # Source repository for repo manifests
 REPO_MANIFESTS_URL ?= https://github.com/nexient-llc/launch-common-automation-framework.git
 # Branch of source repository for repo manifests. Other tags not currently supported.


### PR DESCRIPTION
Causes some problems with our customized version of the repo tool; we have no check for an empty var, so a valueless environment variable wipes out the default version information. We'll need to update our copy of the `repo` tool to address this.